### PR TITLE
Update mkdocs.yml.jinja

### DIFF
--- a/project/mkdocs.yml.jinja
+++ b/project/mkdocs.yml.jinja
@@ -1,6 +1,6 @@
 site_name: "[[ project_name ]]"
 site_description: "[[ project_description ]]"
-site_url: "https://[[ repository_namespace ]].github.io/[[ repository_name ]]"
+site_url: "https://[[ repository_namespace ]].[[ repository_provider.rsplit('.', 1)[0] ]].io/[[ repository_name ]]"
 repo_url: "https://[[ repository_provider ]]/[[ repository_namespace ]]/[[ repository_name ]]"
 repo_name: "[[ repository_namespace ]]/[[ repository_name ]]"
 

--- a/project/mkdocs.yml.jinja
+++ b/project/mkdocs.yml.jinja
@@ -1,7 +1,7 @@
 site_name: "[[ project_name ]]"
 site_description: "[[ project_description ]]"
 site_url: "https://[[ repository_namespace ]].github.io/[[ repository_name ]]"
-repo_url: "https://github.com/[[ repository_namespace ]]/[[ repository_name ]]"
+repo_url: "https://[[ repository_provider ]]/[[ repository_namespace ]]/[[ repository_name ]]"
 repo_name: "[[ repository_namespace ]]/[[ repository_name ]]"
 
 nav:


### PR DESCRIPTION
This fixes the issue I had with it when using this on my gitlab.com account and selecting gitlab during the installation.

mkdocs.yml

Ended up with:
site_url: "https://mikeramsey.github.io/wizard-domaininfo"
repo_url: "https://github.com/mikeramsey/wizard-domaininfo"


Should have been
.gitlab.io gitlab.com
site_url: "https://mikeramsey.gitlab.io/wizard-domaininfo"
repo_url: "https://gitlab.com/mikeramsey/wizard-domaininfo"


There also should be some kind of repository static Pages template variable for

Github = github.io
gitlab = gitlab.io

maybe something like this?
[[ repository_provider_pages ]]

That would make this line
site_url: "https://[[ repository_namespace ]].github.io/[[ repository_name ]]"

Look like this
site_url: "https://[[ repository_namespace ]].[[ repository_provider_pages ]]/[[ repository_name ]]"

Thanks for the awesome tool. I have some more notes and tweaks for gitlab ill be submitting MR for as i finish investigating but its pretty pretty amazing so far.