### PR TITLE
Update mkdocs.yml.jinja

### DIFF
--- a/project/mkdocs.yml.jinja
+++ b/project/mkdocs.yml.jinja
@@ -3,6 +3,7 @@ site_description: "[[ project_description ]]"
 site_url: "https://[[ repository_namespace ]].[[ repository_provider.rsplit('.', 1)[0] ]].io/[[ repository_name ]]"
 repo_url: "https://[[ repository_provider ]]/[[ repository_namespace ]]/[[ repository_name ]]"
 repo_name: "[[ repository_namespace ]]/[[ repository_name ]]"
+site_dir: '[% if repository_provider == "gitlab.com" %]public[% elif repository_provider == "github.com" %]site[% endif %]'
 
 nav:
 - Home:


### PR DESCRIPTION
I think this will fix the mkdocs so it builds to proper path no matter what as it reads from this.

Github
site_dir: 'site'

Gitlab
site_dir: 'public'

I think this should work
site_dir: '[% if repository_provider == "gitlab.com" %]public[% elif repository_provider == "github.com" %]site[% endif %]'


Reference:
https://www.mkdocs.org/user-guide/configuration/#site_dir