### PR TITLE
fix: Stop including README and pyproject.toml in package

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -13,10 +13,6 @@ repository = "https://[[ repository_provider ]]/[[ repository_namespace ]]/[[ re
 homepage = "https://[[ repository_provider ]]/[[ repository_namespace ]]/[[ repository_name ]]"
 keywords = []
 packages = [ { include = "[[ python_package_import_name ]]", from = "src" } ]
-include = [
-    "README.md",
-    "pyproject.toml"
-]
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
These files end up in the site-packages directory directly,
and sometimes race conditions happen and Poetry fails
to install or upgrade packages that include such files,
because they are simultaneously written and deleted
from site-packages.