### PR TITLE
Bugfix/remove flakehell doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ but with [PDM](https://github.com/pdm-project/pdm) instead of Poetry.
   and "autodoc" [mkdocstrings plugin](https://github.com/pawamoy/mkdocstrings))
 - Pre-configured tools for code formatting, quality analysis and testing:
     - [black](https://github.com/psf/black),
-    - [flakehell](https://github.com/life4/flakehell)
-      ([flake8](https://gitlab.com/pycqa/flake8) wrapper) and plugins,
+    - [flake8](https://gitlab.com/pycqa/flake8) and plugins,
     - [isort](https://github.com/timothycrosley/isort),
     - [mypy](https://github.com/python/mypy),
     - [safety](https://github.com/pyupio/safety)

--- a/docs/work.md
+++ b/docs/work.md
@@ -235,10 +235,9 @@ run `make check-types`.
 ### check-code-quality
 
 The code quality analysis is done
-with [Flakehell](https://github.com/life4/flakehell),
-a wrapper around [Flake8](https://flake8.pycqa.org/en/latest/),
+with [Flake8](https://flake8.pycqa.org/en/latest/),
 and a battery of Flake8 plugins.
-The analysis is configured in `pyproject.toml`, section `[tool.flakehell]`.
+The analysis is configured in `config/flake8.ini`.
 In this file, you can deactivate rules
 or activate others to customize your analysis.
 Rules identifiers always start with one or more capital letters,
@@ -297,16 +296,19 @@ markdown_docstring = """
 ```
 
 You can disable a warning globally by adding its ID
-into the list in `pyproject.toml`, section `[tool.flakehell.plugins]`.
+into the list in `config/flake8.ini`.
 
 You can also disable warnings per file, like so:
 
-```toml
-# in pyproject.toml
-[tool.flakehell.exceptions."src/your_package/your_module.py"]
-"*" = [
-    "-WPS407",  # mutable constant
-]
+```ini
+; in config/flake8.ini
+per-file-ignores =
+    ; module imported but unused
+    src/your_package/__init__.py:F401
+    ; continuation line under-indented for hanging indent
+    setup.py:E121
+    ; mutable constant
+    src/your_package/your_module.py:WPS407
 ```
 
 ### check-dependencies

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -38,6 +38,7 @@ toml = "^0.10.2"
 
 # flake8 plugins
 darglint = "^1.5.8"
+flake8 = "^3.7.0"
 flake8-bandit = "^2.1.2"
 flake8-black = "^0.2.1"
 flake8-bugbear = "^20.11.1"


### PR DESCRIPTION
fixes: #15 

this include modified example from flake8 about per file ignore

[docs](https://flake8.pycqa.org/en/4.0.1/user/options.html?highlight=per-file-ignore#cmdoption-flake8-per-file-ignores)

excluding this line `other_project/*:W9` because i don't know what `W9` error mean

also because of that feature, flake8 3.7.0 is required