### PR TITLE
fix: use force flag when delete file

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -9,11 +9,11 @@ _tasks:
 _migrations:
   - version: 0.1.0
     before:
-      - rm docs/changelog.md
-      - rm docs/index.md
-      - rm docs/contributing.md
-      - rm docs/code_of_conduct.md
-      - rm docs/credits.md
+      - rm --force docs/changelog.md
+      - rm --force docs/index.md
+      - rm --force docs/contributing.md
+      - rm --force docs/code_of_conduct.md
+      - rm --force docs/credits.md
 
 # PROMPT --------------------------------
 project_name:


### PR DESCRIPTION
i got this error when running `copier update`

```python
> copier update
# ...
Project sucessfully generated!
Run `make` to show the available actions.
 > Running task 1 of 5: rm docs/changelog.md
rm: cannot remove 'docs/changelog.md': No such file or directory
Traceback (most recent call last):
  File "/home/r3r/.local/bin/copier", line 8, in <module>
    sys.exit(CopierApp.run())
  File "/home/r3r/.local/pipx/venvs/copier/lib/python3.10/site-packages/plumbum/cli/application.py", line 614, in run
    inst, retcode = subapp.run(argv, exit=False)
  File "/home/r3r/.local/pipx/venvs/copier/lib/python3.10/site-packages/plumbum/cli/application.py", line 609, in run
    retcode = inst.main(*tailargs)
  File "/home/r3r/.local/pipx/venvs/copier/lib/python3.10/site-packages/copier/cli.py", line 38, in _wrapper
    return method(*args, **kwargs)
  File "/home/r3r/.local/pipx/venvs/copier/lib/python3.10/site-packages/copier/cli.py", line 296, in main
    self.parent._copy(
  File "/home/r3r/.local/pipx/venvs/copier/lib/python3.10/site-packages/copier/cli.py", line 173, in _copy
    return copy(
  File "/home/r3r/.local/pipx/venvs/copier/lib/python3.10/site-packages/copier/main.py", line 145, in copy
    update_diff(conf=conf)
  File "/home/r3r/.local/pipx/venvs/copier/lib/python3.10/site-packages/copier/main.py", line 281, in update_diff
    run_tasks(conf, renderer, get_migration_tasks(conf, "before"))
  File "/home/r3r/.local/pipx/venvs/copier/lib/python3.10/site-packages/copier/main.py", line 484, in run_tasks
    subprocess.run(task_cmd, shell=use_shell, check=True, env=local.env)
  File "/home/r3r/.pyenv/versions/3.10.0/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'rm docs/changelog.md' returned non-zero exit status 1.
```

based on [^1] it is also possible to use `rm -rf docs/changelog.md || true`, but i think `force` flag is enough for this

[^1]: https://superuser.com/questions/76061/how-do-i-make-rm-not-give-an-error-if-a-file-doesnt-exist