### PR TITLE
fix(pyproject): upgrade pydocstyle

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -50,6 +50,7 @@ flake8-string-format = "^0.3.0"
 flake8-tidy-imports = "^4.2.1"
 flake8-variables-names = "^0.0.4"
 pep8-naming = "^0.11.1"
+pydocstyle = "^6.1.1"
 wps-light = "^0.15.2"
 
 # docs


### PR DESCRIPTION
when make check, there can be error if pydocstyle is not match the version

```python
  > flake8 --config=config/flake8.ini src tests duties.py docs/macros.py
  multiprocessing.pool.RemoteTraceback:
  """
  Traceback (most recent call last):
    File "/home/r3r/.pyenv/versions/3.9.7/lib/python3.9/multiprocessing/pool.py", line 125, in worker
      result = (True, func(*args, **kwds))
    File "/home/r3r/.pyenv/versions/3.9.7/lib/python3.9/multiprocessing/pool.py", line 48, in mapstar
      return list(map(*args))
    File "/home/r3r/.cache/pypoetry/virtualenvs/iqdb-tagger-C28AsU-2-py3.9/lib/python3.9/site-packages/flake8/checker.py", line 676, in _run_checks
      return checker.run_checks()
    File "/home/r3r/.cache/pypoetry/virtualenvs/iqdb-tagger-C28AsU-2-py3.9/lib/python3.9/site-packages/flake8/checker.py", line 589, in run_checks
      self.run_ast_checks()
    File "/home/r3r/.cache/pypoetry/virtualenvs/iqdb-tagger-C28AsU-2-py3.9/lib/python3.9/site-packages/flake8/checker.py", line 494, in run_ast_checks
      for (line_number, offset, text, _) in runner:
    File "/home/r3r/.cache/pypoetry/virtualenvs/iqdb-tagger-C28AsU-2-py3.9/lib/python3.9/site-packages/flake8_docstrings.py", line 140, in run
      pep257.conventions[self.convention] | {'D998', 'D999'}
  KeyError: 'google'
  """

  The above exception was the direct cause of the following exception:

  Traceback (most recent call last):
    File "/home/r3r/.cache/pypoetry/virtualenvs/iqdb-tagger-C28AsU-2-py3.9/bin/flake8", line 8, in <module>
      sys.exit(main())
    File "/home/r3r/.cache/pypoetry/virtualenvs/iqdb-tagger-C28AsU-2-py3.9/lib/python3.9/site-packages/flake8/main/cli.py", line 22, in main
      app.run(argv)
    File "/home/r3r/.cache/pypoetry/virtualenvs/iqdb-tagger-C28AsU-2-py3.9/lib/python3.9/site-packages/flake8/main/application.py", line 363, in run
      self._run(argv)
    File "/home/r3r/.cache/pypoetry/virtualenvs/iqdb-tagger-C28AsU-2-py3.9/lib/python3.9/site-packages/flake8/main/application.py", line 351, in _run
      self.run_checks()
    File "/home/r3r/.cache/pypoetry/virtualenvs/iqdb-tagger-C28AsU-2-py3.9/lib/python3.9/site-packages/flake8/main/application.py", line 264, in run_checks
      self.file_checker_manager.run()
    File "/home/r3r/.cache/pypoetry/virtualenvs/iqdb-tagger-C28AsU-2-py3.9/lib/python3.9/site-packages/flake8/checker.py", line 321, in run
      self.run_parallel()
    File "/home/r3r/.cache/pypoetry/virtualenvs/iqdb-tagger-C28AsU-2-py3.9/lib/python3.9/site-packages/flake8/checker.py", line 287, in run_parallel
      for ret in pool_map:
    File "/home/r3r/.pyenv/versions/3.9.7/lib/python3.9/multiprocessing/pool.py", line 448, in <genexpr>
      return (item for chunk in result for item in chunk)
    File "/home/r3r/.pyenv/versions/3.9.7/lib/python3.9/multiprocessing/pool.py", line 870, in next
      raise value
  KeyError: 'google'
```

flake8-docstring have feature from 1.4 [^1] and pydocstyle support google from version 4.0 [^2]. 

i just choose the latest pydocstyle instead of 4.0 to have all feature & bugfix

[^1]: https://github.com/PyCQA/flake8-docstrings/blob/main/HISTORY.rst#140
[^2]: http://www.pydocstyle.org/en/stable/release_notes.html#july-6th-2019